### PR TITLE
attempt to delete local and remote tags for a deploy if needed

### DIFF
--- a/ceph-deploy/release.yml
+++ b/ceph-deploy/release.yml
@@ -44,6 +44,14 @@
      - name: commit the version changes
        command: git commit -a -m "{{ version }}" chdir=ceph-deploy
 
+     - name: remove local tag
+       command: git tag -d v{{ version }}
+       ignore_errors: yes
+
+     - name: remove remote tag
+       command: git push jenkins :refs/tags/v{{ version }}
+       ignore_errors: yes
+
        # from script: /srv/ceph-build/tag_release.sh
        # Contents of tag_release.sh
      - name: tag and commit the version


### PR DESCRIPTION
If we need to retry a build with the same version number we'll want to try to delete the remote and local tags for that release.
