### PR TITLE
use new GPG key

### DIFF
--- a/ceph-deploy/release.yml
+++ b/ceph-deploy/release.yml
@@ -73,7 +73,7 @@
        # from script: /srv/ceph-build/tag_release.sh
        # Contents of tag_release.sh
      - name: tag and commit the version
-       command: git tag -s "v{{ version }}"  -u 17ED316D -m "v{{ version }}" chdir=ceph-deploy
+       command: git tag -s "v{{ version }}"  -u 9DCEEEAD -m "v{{ version }}" chdir=ceph-deploy
        environment:
          GNUPGHOME: ~/build/gnupg.ceph-release
          DEBEMAIL: "{{ debemail }}"
@@ -96,6 +96,6 @@
      - name: ensure GPG keys exist for release
        command: gpg --list-keys
        register: command_result
-       failed_when: "'17ED316D' not in command_result.stdout"
+       failed_when: "'9DCEEEAD' not in command_result.stdout"
        environment:
          GNUPGHOME: ~/build/gnupg.ceph-release/

--- a/ceph/tasks/setup.yml
+++ b/ceph/tasks/setup.yml
@@ -68,7 +68,7 @@
 
        # from script: /srv/ceph-build/tag_release.sh
      - name: tag and commit the version
-       command: git tag -s "v{{ version }}"  -u 17ED316D -m "v{{ version }}" chdir=ceph
+       command: git tag -s "v{{ version }}"  -u 9DCEEEAD -m "v{{ version }}" chdir=ceph
        environment:
          GNUPGHOME: ~/build/gnupg.ceph-release
 
@@ -83,6 +83,6 @@
      - name: ensure GPG keys exist for release
        command: gpg --list-keys
        register: command_result
-       failed_when: "'17ED316D' not in command_result.stdout"
+       failed_when: "'9DCEEEAD' not in command_result.stdout"
        environment:
          GNUPGHOME: ~/build/gnupg.ceph-release/

--- a/radosgw-agent/release.yml
+++ b/radosgw-agent/release.yml
@@ -76,7 +76,7 @@
        # from script: /srv/ceph-build/tag_release.sh
        # Contents of tag_release.sh
      - name: tag and commit the version
-       command: git tag -s "v{{ version }}"  -u 17ED316D -m "v{{ version }}" chdir=radosgw-agent
+       command: git tag -s "v{{ version }}"  -u 9DCEEEAD -m "v{{ version }}" chdir=radosgw-agent
        environment:
          GNUPGHOME: ~/build/gnupg.ceph-release
          DEBEMAIL: "{{ debemail }}"
@@ -99,6 +99,6 @@
      - name: ensure GPG keys exist for release
        command: gpg --list-keys
        register: command_result
-       failed_when: "'17ED316D' not in command_result.stdout"
+       failed_when: "'9DCEEEAD' not in command_result.stdout"
        environment:
          GNUPGHOME: ~/build/gnupg.ceph-release/


### PR DESCRIPTION
See
http://ceph.com/releases/important-security-notice-regarding-signing-key-and-binary-downloads-of-ceph/

17ED316D is the old key

9DCEEEAD is the new key