### PR TITLE
ceph: rm GPG signing

### DIFF
--- a/ceph/tasks/setup.yml
+++ b/ceph/tasks/setup.yml
@@ -68,21 +68,10 @@
 
        # from script: /srv/ceph-build/tag_release.sh
      - name: tag and commit the version
-       command: git tag -s "v{{ version }}"  -u 17ED316D -m "v{{ version }}" chdir=ceph
-       environment:
-         GNUPGHOME: ~/build/gnupg.ceph-release
+       command: git tag -a "v{{ version }}" -m "v{{ version }}" chdir=ceph
 
      - name: push changes to jenkins git repo
        command: git push jenkins {{ branch }} chdir=ceph
 
      - name: push the newly created tag
        command: git push jenkins v{{ version }} chdir=ceph
-       environment:
-         GNUPGHOME: ~/build/gnupg.ceph-release
-
-     - name: ensure GPG keys exist for release
-       command: gpg --list-keys
-       register: command_result
-       failed_when: "'17ED316D' not in command_result.stdout"
-       environment:
-         GNUPGHOME: ~/build/gnupg.ceph-release/


### PR DESCRIPTION
The unprivileged UID on our Jenkins server that normally does the version bump and git tag no longer has access to Ceph's new GPG signing key. We're doing that another way now.

Remove the steps in the ceph task that used the GPG key to sign the git tag.