### PR TITLE
kraken: set FACTS_REQUIRE_NICKNAME

### DIFF
--- a/kraken/roles/common/templates/custom_settings.j2
+++ b/kraken/roles/common/templates/custom_settings.j2
@@ -41,3 +41,5 @@ TWITTER_USERNAME = {{ helga_twitter_username }}
 
 BUGZILLA_XMLRPC_URL = "{{ bugzilla_xmlrpc_url }}"
 BUGZILLA_TICKET_URL = "{{ bugzilla_ticket_url }}"
+
+FACTS_REQUIRE_NICKNAME = True


### PR DESCRIPTION
This causes the "helga-facts" plugin to restrict kraken's responses. Kraken's nick will be required to show a stored fact.